### PR TITLE
Add constexpr and const qualifiers

### DIFF
--- a/src/components/has_waiting_queue.h
+++ b/src/components/has_waiting_queue.h
@@ -7,7 +7,7 @@
 using EntityID = int;
 
 struct HasWaitingQueue : public BaseComponent {
-    static const int max_queue_size = 3;
+    static constexpr int max_queue_size = 3;
 
     virtual ~HasWaitingQueue() {}
 

--- a/src/components/is_floor_marker.h
+++ b/src/components/is_floor_marker.h
@@ -4,7 +4,7 @@
 #include "../engine/log.h"
 #include "base_component.h"
 
-const int MAX_FLOOR_MARKERS = 100;
+constexpr int MAX_FLOOR_MARKERS = 100;
 
 struct IsFloorMarker : public BaseComponent {
     enum Type {

--- a/src/components/model_renderer.h
+++ b/src/components/model_renderer.h
@@ -29,9 +29,7 @@ struct ModelRenderer : public BaseComponent {
     }
     [[nodiscard]] const std::string& name() const { return model_name; }
 
-    void update_model_name(const std::string& new_name) {
-        model_name = new_name;
-    }
+    void update_model_name(std::string_view new_name) { model_name = new_name; }
 
    private:
     std::string model_name;

--- a/src/components/uses_character_model.h
+++ b/src/components/uses_character_model.h
@@ -22,8 +22,8 @@ struct UsesCharacterModel : public BaseComponent {
         changed = true;
     }
 
-    [[nodiscard]] const std::string& fetch_model_name() const {
-        return strings::character_models[index];
+    [[nodiscard]] std::string fetch_model_name() const {
+        return std::string(strings::character_models[index]);
     }
 
     [[nodiscard]] bool value_same_as_last_render() const {

--- a/src/drawing_util.h
+++ b/src/drawing_util.h
@@ -19,7 +19,7 @@ static void DrawPctFilledCircle(const vec2 position, float radius,
                                 Color backgroundColor, Color foregroundColor,
                                 float pct_filled, float startAngle = 180) {
     const float endAngle = startAngle + (360 * pct_filled);
-    const int segments = 40;
+    constexpr int segments = 40;
 
     raylib::DrawCircle((int) position.x, (int) position.y, radius,
                        backgroundColor);
@@ -169,7 +169,7 @@ static void DrawCubeCustom(Vector3 position, float width, float height,
     rlPopMatrix();
 }
 
-static void DrawFloatingText(const vec3& position, Font font, const char* text,
+static void DrawFloatingText(const vec3& position, const Font& font, const char* text,
                              int size = 96, Color color = BLACK,
                              bool backface = true,
                              std::string texture_name = "",

--- a/src/engine/bfs.h
+++ b/src/engine/bfs.h
@@ -11,7 +11,7 @@
 #include "util.h"
 
 namespace bfs {
-const int MAX_PATH_LENGTH = 50;
+constexpr int MAX_PATH_LENGTH = 50;
 
 static constexpr int neigh_x[8] = {-1, -1, -1, 0, 0, 1, 1, 1};
 static constexpr int neigh_y[8] = {-1, 0, 1, -1, 1, -1, 0, 1};

--- a/src/engine/settings.h
+++ b/src/engine/settings.h
@@ -33,7 +33,7 @@ using InputAdapter = bitsery::InputBufferAdapter<Buffer>;
 // TODO how do we support different games having different save file data
 // requirements?
 
-const int MAX_LANG_LENGTH = 25;
+constexpr int MAX_LANG_LENGTH = 25;
 
 // TODO How do we support multiple versions
 // we dont want to add a new field and break

--- a/src/engine/ui/autolayout.h
+++ b/src/engine/ui/autolayout.h
@@ -29,7 +29,7 @@ namespace autolayout {
 // }
 // }
 
-const float ACCEPTABLE_ERROR = 0.5f;
+constexpr float ACCEPTABLE_ERROR = 0.5f;
 
 inline float compute_size_for_standalone_expectation(Widget* widget,
                                                      int exp_index) {

--- a/src/engine/ui/color.h
+++ b/src/engine/ui/color.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "../../vec_util.h"
@@ -103,19 +102,19 @@ inline Color getHighlighted(const Color& color) {
     return toRGB(hsl);
 }
 
-static const Color transleucent_green = Color{0, 250, 50, 5};
-static const Color transleucent_red = Color{250, 0, 50, 5};
+static constexpr Color transleucent_green = Color{0, 250, 50, 5};
+static constexpr Color transleucent_red = Color{250, 0, 50, 5};
 
-static const Color pacific_blue = Color{71, 168, 189, 255};
-static const Color oxford_blue = Color{12, 27, 51, 255};
-static const Color orange_soda = Color{240, 100, 73, 255};
-static const Color isabelline = Color{237, 230, 227, 255};
-static const Color tea_green = Color{195, 232, 189, 255};
+static constexpr Color pacific_blue = Color{71, 168, 189, 255};
+static constexpr Color oxford_blue = Color{12, 27, 51, 255};
+static constexpr Color orange_soda = Color{240, 100, 73, 255};
+static constexpr Color isabelline = Color{237, 230, 227, 255};
+static constexpr Color tea_green = Color{195, 232, 189, 255};
 
 // This is the original xkcd cerulean but i prefer the other one
 // static const Color cerulean = Color{4, 133, 209, 255};
 
-static const Color cerulean = Color{0, 126, 167, 255};
+static constexpr Color cerulean = Color{0, 126, 167, 255};
 
 // "secondary": [33, 158, 188, 255], // nice blue but too close to pacific
 

--- a/src/engine/ui/focus.h
+++ b/src/engine/ui/focus.h
@@ -12,8 +12,8 @@ namespace ui {
 extern std::shared_ptr<ui::UIContext> context;
 
 namespace focus {
-const int ROOT_ID = -1;
-const int FAKE_ID = -2;
+constexpr int ROOT_ID = -1;
+constexpr int FAKE_ID = -2;
 extern int focus_id;
 extern int last_processed;
 extern int hot_id;

--- a/src/engine/util.h
+++ b/src/engine/util.h
@@ -49,15 +49,15 @@ int sgn(T val) {
     return (T(0) < val) - (val < T(0));
 }
 
-static float deg2rad(float deg) {
+constexpr float deg2rad(float deg) {
     return deg * static_cast<float>(M_PI) / 180.0f;
 }
 
-static float rad2deg(float rad) {
+constexpr float rad2deg(float rad) {
     return rad * (180.f / static_cast<float>(M_PI));
 }
 
-static bool in_range(int a, int b, int val) { return val >= a && val <= b; }
+constexpr bool in_range(int a, int b, int val) { return val >= a && val <= b; }
 
 static std::string toLowerCase(const std::string_view& str) {
     std::string result;
@@ -140,7 +140,7 @@ inline std::string convertToSnakeCase(T type) {
     return snake_case(magic_enum::enum_name(type));
 }
 
-static float clamp(float a, float mn, float mx) {
+constexpr float clamp(float a, float mn, float mx) {
     return std::min(std::max(a, mn), mx);
 }
 
@@ -164,7 +164,7 @@ static float trunc(float value, int decimal_places) {
     return std::trunc(value * multiplier) / multiplier;
 }
 
-static float lerp(float a, float b, float pct) {
+constexpr float lerp(float a, float b, float pct) {
     return (a * (1 - pct)) + (b * pct);
 }
 
@@ -178,7 +178,7 @@ inline V map_get_or_default(Container<K, V, Ts...> map, K key, V def_value) {
 }
 
 template<typename T>
-[[nodiscard]] constexpr bool contains(std::vector<T> array, const T& key) {
+[[nodiscard]] constexpr bool contains(const std::vector<T>& array, const T& key) {
     const auto itr = std::find_if(std::begin(array), std::end(array),
                                   [&key](const auto& v) { return v == key; });
     return itr != std::end(array);

--- a/src/layers/recipe_book_layer.h
+++ b/src/layers/recipe_book_layer.h
@@ -2,7 +2,7 @@
 
 #include "base_game_renderer.h"
 
-const int MAX_VISIBLE_IGS = 10;
+constexpr int MAX_VISIBLE_IGS = 10;
 
 struct RecipeBookLayer : public BaseGameRendererLayer {
     bool should_show_recipes = false;

--- a/src/layers/toastlayer.h
+++ b/src/layers/toastlayer.h
@@ -27,7 +27,7 @@ struct ToastLayer : public BaseGameRendererLayer {
         window = rect::tpad(window, 10);
         window = rect::bpad(window, 95);
 
-        const int MX_TOASTS = 10;
+        constexpr int MX_TOASTS = 10;
         auto toast_spots = rect::hsplit<MX_TOASTS>(window, 10);
 
         const auto background_color = [](AnnouncementType type) {

--- a/src/network/internal/server.h
+++ b/src/network/internal/server.h
@@ -173,7 +173,7 @@ struct Server {
         /// estimate the bandwidth of the channel and set the send rate to that
         /// estimated bandwidth, and these values will only set limits on that
         /// send rate.
-        constexpr const int rate = 1024 * 1024 * 1024;
+        constexpr int rate = 1024 * 1024 * 1024;
         SteamNetworkingUtils()->SetGlobalConfigValueInt32(
             k_ESteamNetworkingConfig_SendRateMin, rate);
         SteamNetworkingUtils()->SetGlobalConfigValueInt32(

--- a/src/strings.h
+++ b/src/strings.h
@@ -126,7 +126,7 @@ constexpr const char* CHARACTER_RUTH = "character_ruth";
 
 }  // namespace model
 
-const std::array<std::string, 7> character_models = {
+constexpr std::array<std::string_view, 7> character_models = {
     strings::model::CHARACTER_BEAR, strings::model::CHARACTER_DOG,
     strings::model::CHARACTER_DUCK, strings::model::CHARACTER_ROGUE,
     strings::model::CHARACTER_GABE, strings::model::CHARACTER_GABE2,
@@ -390,7 +390,7 @@ enum struct TodoReason {
 };
 
 struct TranslatableString {
-    static const int MAX_LENGTH = 100;
+    static constexpr int MAX_LENGTH = 100;
 
     explicit TranslatableString() {}
     explicit TranslatableString(const std::string& s) : content(s) {}

--- a/src/system/rendering_system.cpp
+++ b/src/system/rendering_system.cpp
@@ -645,7 +645,7 @@ void render_trigger_area(const Entity& entity, float dt) {
                                              .waveOffset = {0.f, 0.f, 0.2f}};
 
         raylib::DrawTextWave3D(textConfig,             //
-                               &waveConfig,            //
+                               waveConfig,             //
                                now::current_hrc_ms(),  //
                                WHITE);
 

--- a/src/text_util.h
+++ b/src/text_util.h
@@ -11,8 +11,8 @@ namespace raylib {
 #define TEXT_MAX_LAYERS 32
 #define LETTER_BOUNDRY_COLOR VIOLET
 
-const bool SHOW_LETTER_BOUNDRY = false;
-const bool SHOW_TEXT_BOUNDRY = false;
+constexpr bool SHOW_LETTER_BOUNDRY = false;
+constexpr bool SHOW_TEXT_BOUNDRY = false;
 
 using DrawTextConfig = struct DrawTextConfig {
     Font font;
@@ -121,7 +121,7 @@ static void DrawTextCodepoint3D(Font font, int codepoint, vec3 position,
 }
 
 // Draw a 2D text in 3D space
-static void DrawText3D(DrawTextConfig& config) {
+static void DrawText3D(const DrawTextConfig& config) {
     const auto [font, text, position, fontSize, fontSpacing, lineSpacing,
                 backface, color] = config;
 
@@ -233,8 +233,9 @@ static vec3 MeasureText3D(Font font, const char* text, float fontSize,
 // Draw a 2D text in 3D space and wave the parts that start with `~~` and end
 // with `~~`. This is a modified version of the original code by @Nighten found
 // here https://github.com/NightenDushi/Raylib_DrawTextStyle
-static void DrawTextWave3D(DrawTextConfig& text_config, WaveTextConfig* config,
-                           float time, Color tint) {
+static void DrawTextWave3D(const DrawTextConfig& text_config,
+                           const WaveTextConfig& config, float time,
+                           Color tint) {
     const auto [font, text, position, fontSize, fontSpacing, lineSpacing,
                 backface, color] = text_config;
 
@@ -276,15 +277,15 @@ static void DrawTextWave3D(DrawTextConfig& text_config, WaveTextConfig* config,
                 vec3 pos = position;
                 if (wave)  // Apply the wave effect
                 {
-                    pos.x += sinf(time * config->waveSpeed.x -
-                                  k * config->waveOffset.x) *
-                             config->waveRange.x;
-                    pos.y += sinf(time * config->waveSpeed.y -
-                                  k * config->waveOffset.y) *
-                             config->waveRange.y;
-                    pos.z += sinf(time * config->waveSpeed.z -
-                                  k * config->waveOffset.z) *
-                             config->waveRange.z;
+                    pos.x += sinf(time * config.waveSpeed.x -
+                                  k * config.waveOffset.x) *
+                             config.waveRange.x;
+                    pos.y += sinf(time * config.waveSpeed.y -
+                                  k * config.waveOffset.y) *
+                             config.waveRange.y;
+                    pos.z += sinf(time * config.waveSpeed.z -
+                                  k * config.waveOffset.z) *
+                             config.waveRange.z;
                 }
 
                 DrawTextCodepoint3D(

--- a/src/vec_util.h
+++ b/src/vec_util.h
@@ -46,7 +46,7 @@ template<typename T>
 }
 
 template<typename T>
-[[nodiscard]] bool contains(const std::vector<T>& vec, T& value) {
+[[nodiscard]] bool contains(const std::vector<T>& vec, const T& value) {
     return std::find(vec.begin(), vec.end(), value) != vec.end();
 }
 }  // namespace vector
@@ -71,7 +71,7 @@ namespace vec {
 static constexpr int neigh_x[8] = {-1, -1, -1, 0, 0, 1, 1, 1};
 static constexpr int neigh_y[8] = {-1, 0, 1, -1, 1, -1, 0, 1};
 
-static void forEachNeighbor(int i, int j, std::function<void(const vec2&)> cb,
+static void forEachNeighbor(int i, int j, const std::function<void(const vec2&)>& cb,
                             int step = 1) {
     for (int a = 0; a < 8; a++) {
         cb(vec2{(float) i + (neigh_x[a] * step),


### PR DESCRIPTION
Add `constexpr` and `const` qualifiers to improve compile-time evaluation and const-correctness.

---
<a href="https://cursor.com/background-agent?bcId=bc-463bed83-d65c-46be-ad96-5c416cb2fc97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-463bed83-d65c-46be-ad96-5c416cb2fc97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

