### PR TITLE
Optimize entity registry for faster lookups

### DIFF
--- a/src/entity_helper.h
+++ b/src/entity_helper.h
@@ -47,6 +47,10 @@ struct EntityHelper {
     static Entities& get_entities_for_mod();
     static RefEntities get_ref_entities();
 
+    // Rebuild the O(1) id -> shared_ptr registry from the current entities
+    // container for the active (client/server) context.
+    static void rebuild_id_registry();
+
     static Entity& createEntity();
     static Entity& createPermanentEntity();
     static Entity& createEntityWithOptions(const CreationOptions& options);
@@ -90,18 +94,9 @@ struct EntityHelper {
         const std::function<bool(const Entity&)>& filter);
 
     // TODO exists as a conversion for things that need shared_ptr right now
-    static std::shared_ptr<Entity> getEntityAsSharedPtr(const Entity& entity) {
-        for (std::shared_ptr<Entity> current_entity : get_entities()) {
-            if (entity.id == current_entity->id) return current_entity;
-        }
-        return {};
-    }
+    static std::shared_ptr<Entity> getEntityAsSharedPtr(const Entity& entity);
 
-    static std::shared_ptr<Entity> getEntityAsSharedPtr(OptEntity entity) {
-        if (!entity) return {};
-        const Entity& e = entity.asE();
-        return getEntityAsSharedPtr(e);
-    }
+    static std::shared_ptr<Entity> getEntityAsSharedPtr(OptEntity entity);
 
     static OptEntity getClosestMatchingFurniture(
         const Transform& transform, float range,

--- a/src/network/client.cpp
+++ b/src/network/client.cpp
@@ -6,6 +6,7 @@
 #include "../engine/globals_register.h"
 #include "../engine/log.h"
 #include "../engine/sound_library.h"
+#include "../entity_helper.h"
 #include "network.h"
 
 namespace network {
@@ -278,6 +279,8 @@ void Client::client_process_message_string(const std::string& msg) {
 
             client_entities_DO_NOT_USE.clear();
             client_entities_DO_NOT_USE = info.map.entities();
+            // Rebuild id registry for client side
+            EntityHelper::rebuild_id_registry();
 
             map->update_map(info.map);
 


### PR DESCRIPTION
Implement an O(1) `EntityRegistry` (id → shared_ptr) to remove linear scans and ensure safer shared ownership.

This PR introduces an `EntityRegistry` that maps entity IDs to `std::weak_ptr<Entity>`, enabling O(1) lookups for entities by ID. This replaces several linear scans in `EntityHelper` methods like `getEntityForID` and `markIDForCleanup`, improving performance. Additionally, `getEntityAsSharedPtr` now returns the canonical `shared_ptr` from the registry, ensuring consistent shared ownership and preventing potential lifetime issues. The registry is kept in sync with entity lifecycle events (creation, removal, cleanup, and client map updates).

---
<a href="https://cursor.com/background-agent?bcId=bc-a8c0bdf5-6488-49c0-98ff-fe1dc4a237ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8c0bdf5-6488-49c0-98ff-fe1dc4a237ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

