### PR TITLE
fix: raylib 5.5 DrawRectangleRoundedLines -> ...LinesEx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/afterhours"]
+	path = vendor/afterhours
+	url = https://github.com/gabeochoa/afterhours

--- a/src/ah.h
+++ b/src/ah.h
@@ -1,0 +1,5 @@
+
+#include "bitsery_include.h"
+
+#define ENABLE_AFTERHOURS_BITSERY_SERIALIZE
+#include "afterhours/ah.h"

--- a/src/components/adds_ingredient.h
+++ b/src/components/adds_ingredient.h
@@ -64,3 +64,4 @@ struct AddsIngredient : public BaseComponent {
         s.value4b(num_uses);
     }
 };
+

--- a/src/components/base_component.h
+++ b/src/components/base_component.h
@@ -1,63 +1,21 @@
 
 #pragma once
 
-#include <array>
-#include <bitset>
-#include <map>
-#include <memory>
-
 #include "../bitsery_include.h"
 #include "../globals.h"
+#include "afterhours/ah.h"
+#include "afterhours/src/base_component.h"
 
-struct Entity;
-using Entities = std::vector<std::shared_ptr<Entity>>;
+using afterhours::Entity;
+using afterhours::EntityID;
 using bitsery::ext::PointerObserver;
 
-struct BaseComponent;
-constexpr int max_num_components = 128;
-using ComponentID = int;
+using afterhours::BaseComponent;
 
-namespace components {
-namespace internal {
-inline ComponentID get_unique_id() noexcept {
-    static ComponentID lastID{0};
-    // TODO this doesnt work for some reason
-    // if (lastID + 1 > max_num_components)
-    // log_error(
-    // "You are trying to add a new component but you have used up all "
-    // "the space allocated, updated max_num");
-    return lastID++;
+namespace bitsery {
+template<typename S>
+void serialize(S& s, afterhours::BaseComponent& component) {
+    s.ext(component.parent, PointerObserver{});
 }
 
-}  // namespace internal
-
-template<typename T>
-inline ComponentID get_type_id() noexcept {
-    static_assert(std::is_base_of<BaseComponent, T>::value,
-                  "T must inherit from BaseComponent");
-    static ComponentID typeID{internal::get_unique_id()};
-    return typeID;
-}
-}  // namespace components
-
-struct BaseComponent {
-    Entity* parent = nullptr;
-
-    BaseComponent() {}
-    BaseComponent(BaseComponent&&) = default;
-
-    void attach_parent(Entity* p) {
-        parent = p;
-        onAttach();
-    }
-
-    virtual void onAttach() {}
-    virtual ~BaseComponent() {}
-
-   private:
-    friend bitsery::Access;
-    template<typename S>
-    void serialize(S& s) {
-        s.ext(parent, PointerObserver{});
-    }
-};
+}  // namespace bitsery

--- a/src/components/can_be_highlighted.h
+++ b/src/components/can_be_highlighted.h
@@ -3,8 +3,6 @@
 
 #include "base_component.h"
 
-struct Entity;
-
 using OnChangeFn = std::function<void(Entity&, bool)>;
 
 struct CanBeHighlighted : public BaseComponent {

--- a/src/components/can_hold_item.h
+++ b/src/components/can_hold_item.h
@@ -4,12 +4,12 @@
 #include <optional>
 //
 
-#include "../entity.h"
 #include "base_component.h"
 //
 #include "../dataclass/entity_filter.h"
 #include "has_subtype.h"
 #include "is_item.h"
+#include "type.h"
 
 struct CanHoldItem : public BaseComponent {
     CanHoldItem() : held_by(EntityType::Unknown), filter(EntityFilter()) {}
@@ -46,7 +46,7 @@ struct CanHoldItem : public BaseComponent {
             log_warn(
                 "We never had our HeldBy set, so we are holding {}{}  by "
                 "UNKNOWN",
-                item->id, item->name());
+                item->id, item->get<Type>().name());
         }
         return *this;
     }

--- a/src/components/has_waiting_queue.cpp
+++ b/src/components/has_waiting_queue.cpp
@@ -1,12 +1,14 @@
 
 #include "has_waiting_queue.h"
 
+#include "../components/type.h"
+#include "../engine/assert.h"
 #include "../engine/log.h"
 #include "../entity.h"
 
 HasWaitingQueue& HasWaitingQueue::add_customer(const Entity& customer) {
     log_info("we are adding {} {} to the line in position {}", customer.id,
-             customer.name(), next_line_position);
+             customer.get<Type>().name(), next_line_position);
     ppl_in_line[next_line_position] = customer.id;
     next_line_position++;
 

--- a/src/components/has_work.h
+++ b/src/components/has_work.h
@@ -4,7 +4,7 @@
 
 #include "base_component.h"
 
-struct Entity;
+using afterhours::Entity;
 
 struct HasWork : public BaseComponent {
     HasWork()

--- a/src/components/is_spawner.h
+++ b/src/components/is_spawner.h
@@ -5,7 +5,7 @@
 #include "../vendor_include.h"
 #include "base_component.h"
 
-struct Entity;
+using afterhours::Entity;
 
 struct SpawnInfo {
     vec2 location;

--- a/src/components/type.h
+++ b/src/components/type.h
@@ -1,0 +1,27 @@
+
+#pragma once
+
+//
+#include "../entity_type.h"
+#include "base_component.h"
+
+struct Type : public BaseComponent {
+    virtual ~Type() {}
+    Type() {}
+
+    explicit Type(EntityType t) : type(t) {}
+
+    EntityType type = EntityType::Unknown;
+
+    const std::string_view name() const {
+        return magic_enum::enum_name<EntityType>(type);
+    }
+
+   private:
+    friend bitsery::Access;
+    template<typename S>
+    void serialize(S& s) {
+        s.ext(*this, bitsery::ext::BaseClass<BaseComponent>{});
+        s.value4b(type);
+    }
+};

--- a/src/dataclass/entity_filter.h
+++ b/src/dataclass/entity_filter.h
@@ -10,6 +10,7 @@
 #include "../components/has_subtype.h"
 #include "../components/is_drink.h"
 #include "../components/is_item.h"
+#include "../components/type.h"
 #include "ingredient.h"
 
 enum RespectFilter { All, ReqOnly, Ignore };
@@ -148,10 +149,11 @@ struct EntityFilter {
     T read_filter_value_from_entity(const Entity& entity,
                                     FilterDatumType type) const {
         if constexpr (std::is_same_v<T, std::string>) {
-            if (type & FilterDatumType::Name) return std::string(entity.name());
+            if (type & FilterDatumType::Name)
+                return std::string(entity.get<Type>().name());
         } else if constexpr (std::is_same_v<T, EntityType>) {
             if (type & FilterDatumType::Name) {
-                return entity.type;
+                return entity.get<Type>().type;
             }
         } else if constexpr (std::is_same_v<T, int>) {
             if (type & FilterDatumType::Subtype) {

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1,24 +1,14 @@
 
 #include "entity.h"
 
-Entity::~Entity() {
-    // for (auto itr = componentArray.begin(); itr != componentArray.end();
-    // itr++) {
-    // if (itr->second) delete (itr->second);
-    // }
-    componentArray.clear();
-}
-
-const std::string_view Entity::name() const {
-    return magic_enum::enum_name<EntityType>(type);
-}
+#include "components/type.h"
 
 bool check_type(const Entity& entity, EntityType type) {
-    return type == entity.type;
+    return type == entity.get<Type>().type;
 }
 
 bool check_if_drink(const Entity& entity) {
-    switch (entity.type) {
+    switch (entity.get<Type>().type) {
         case EntityType::Unknown:
         case EntityType::x:
         case EntityType::y:

--- a/src/entity.h
+++ b/src/entity.h
@@ -3,6 +3,8 @@
 
 #include "afterhours/ah.h"
 using afterhours::Entity;
+using afterhours::OptEntity;
+using afterhours::RefEntity;
 
 #include "bitsery/ext/std_bitset.h"
 #include "bitsery/ext/std_smart_ptr.h"
@@ -18,40 +20,6 @@ using afterhours::Entity;
 struct DebugOptions {
     EntityType type = EntityType::Unknown;
     bool enableCharacterModel = true;
-};
-
-using RefEntity = std::reference_wrapper<Entity>;
-using OptEntityType = std::optional<std::reference_wrapper<Entity>>;
-
-struct OptEntity {
-    OptEntityType data;
-
-    OptEntity() {}
-    OptEntity(OptEntityType opt_e) : data(opt_e) {}
-    OptEntity(RefEntity _e) : data(_e) {}
-    OptEntity(Entity& _e) : data(_e) {}
-
-    bool has_value() const { return data.has_value(); }
-    bool valid() const { return has_value(); }
-
-    Entity* value() { return &(data.value().get()); }
-    Entity* operator*() { return value(); }
-    Entity* operator->() { return value(); }
-
-    const Entity* value() const { return &(data.value().get()); }
-    const Entity* operator*() const { return value(); }
-    // TODO look into switching this to using functional monadic stuff
-    // i think optional.transform can take and handle calling functions on an
-    // optional without having to expose the underlying value or existance of
-    // value
-    const Entity* operator->() const { return value(); }
-
-    Entity& asE() { return data.value(); }
-    const Entity& asE() const { return data.value(); }
-
-    operator RefEntity() { return data.value(); }
-    operator RefEntity() const { return data.value(); }
-    operator bool() const { return valid(); }
 };
 
 using Item = Entity;

--- a/src/entity_helper.cpp
+++ b/src/entity_helper.cpp
@@ -281,7 +281,7 @@ OptEntity EntityHelper::getMatchingEntityInFront(
                 log_warn("component {} is missing transform",
                          current_entity->id);
                 log_error("component {} is missing name",
-                          current_entity->name());
+                          current_entity->get<Type>().name());
                 continue;
             }
 

--- a/src/entity_helper.h
+++ b/src/entity_helper.h
@@ -26,11 +26,13 @@ enum struct NamedEntity {
     Sophie,
 };
 
-using Entities = std::vector<std::shared_ptr<Entity>>;
-using RefEntities = std::vector<RefEntity>;
+using Entities = std::vector<std::shared_ptr<afterhours::Entity>>;
+using RefEntities = std::vector<afterhours::RefEntity>;
+
 using NamedEntities = std::map<NamedEntity, std::shared_ptr<Entity>>;
 
 extern Entities client_entities_DO_NOT_USE;
+extern Entities server_entities_DO_NOT_USE;
 extern NamedEntities named_entities_DO_NOT_USE;
 
 extern std::set<int> permanant_ids;

--- a/src/entity_makers.cpp
+++ b/src/entity_makers.cpp
@@ -31,6 +31,7 @@
 #include "components/is_store_spawned.h"
 #include "components/is_toilet.h"
 #include "components/responds_to_day_night.h"
+#include "components/type.h"
 #include "dataclass/ingredient.h"
 #include "dataclass/upgrade_class.h"
 #include "engine/bitset_utils.h"
@@ -142,7 +143,7 @@ bool _add_item_to_drink_NO_VALIDATION(Entity& drink, Item& toadd) {
 void register_all_components() {
     Entity* entity = new Entity();
     entity->addAll<  //
-        Transform, HasName,
+        Transform, HasName, Type,
         //
         AICleanVomit, AIUseBathroom, AIDrinking, AIWaitInQueue, AICloseTab,
         AIPlayJukebox, AIWandering,
@@ -227,7 +228,7 @@ void add_person_components(Entity& person, DebugOptions options = {}) {
 }
 
 void make_entity(Entity& entity, const DebugOptions& options, vec3 p) {
-    entity.type = options.type;
+    entity.addComponent<Type>(options.type);
 
     add_entity_components(entity);
     entity.get<Transform>().update(p);
@@ -1782,7 +1783,7 @@ bool convert_to_type(const EntityType& entity_type, Entity& entity,
         }
     }
 
-    if (entity.type == EntityType::Unknown) {
+    if (entity.get<Type>().type == EntityType::Unknown) {
         log_error(
             "Created an entity but somehow didnt get a type {}"
             "type",

--- a/src/entity_query.cpp
+++ b/src/entity_query.cpp
@@ -56,7 +56,8 @@ EntityQuery& EntityQuery::whereIsHoldingItemOfType(EntityType type) {
         add_mod(new WhereHasComponent<CanHoldItem>())
             .add_mod(new WhereLambda([type](const Entity& entity) {
                 const CanHoldItem& chi = entity.get<CanHoldItem>();
-                return chi.is_holding_item() && chi.item().type == type;
+                return chi.is_holding_item() &&
+                       chi.item().get<Type>().type == type;
             }));
 }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -17,8 +17,6 @@ constexpr int MAP_H = 33;
 // if you change this here, then go in there and add support as well
 constexpr float TILESIZE = 1.0f;
 
-struct Entity;
-
 constexpr float GATHER_SPOT = -20.f;
 constexpr int MAX_SEARCH_RANGE = 100;
 

--- a/src/job.h
+++ b/src/job.h
@@ -1,13 +1,12 @@
 
 #pragma once
 
+#include "afterhours/ah.h"
+using afterhours::Entity;
 #include "engine/assert.h"
 #include "engine/log.h"
 #include "external_include.h"
 //
-
-using EntityID = int;
-struct Entity;
 
 enum JobType {
     NoJob = 0,

--- a/src/layers/gamedebuglayer.cpp
+++ b/src/layers/gamedebuglayer.cpp
@@ -75,14 +75,17 @@ void GameDebugLayer::draw_debug_ui(float dt) {
                      NO_TRANSLATE(
                          fmt::format("{}", (player->get<Transform>().pos()))));
                 text(Widget{holding_div},
-                     NO_TRANSLATE(
-                         fmt::format("holding furniture?: {}",
-                                     furniture ? furniture->name() : "Empty")));
+                     NO_TRANSLATE(fmt::format(
+                         "holding furniture?: {}",
+                         furniture ? furniture->get<Type>().name() : "Empty")));
                 text(Widget{item_div},
                      NO_TRANSLATE(fmt::format(
                          "holding item?: {}",
                          player->get<CanHoldItem>().is_holding_item()
-                             ? player->get<CanHoldItem>().const_item().name()
+                             ? player->get<CanHoldItem>()
+                                   .const_item()
+                                   .get<Type>()
+                                   .name()
                              : "Empty")));
             } else {
                 text(Widget{player_info},

--- a/src/layers/gamelayer.h
+++ b/src/layers/gamelayer.h
@@ -2,9 +2,10 @@
 
 #include "../camera.h"
 #include "../engine/layer.h"
+#include "afterhours/ah.h"
 
 struct GameLayer : public Layer {
-    std::shared_ptr<Entity> active_player;
+    std::shared_ptr<afterhours::Entity> active_player;
     std::unique_ptr<GameCam> cam;
     raylib::Model bag_model;
     raylib::RenderTexture2D game_render_texture;

--- a/src/network/polymorphic_components.h
+++ b/src/network/polymorphic_components.h
@@ -1,5 +1,6 @@
 
 #pragma once
+
 #include "../external_include.h"
 //
 
@@ -67,13 +68,160 @@
 #include "../components/responds_to_user_input.h"
 #include "../components/simple_colored_box_renderer.h"
 #include "../components/transform.h"
+#include "../components/type.h"
 #include "../components/uses_character_model.h"
+#include "bitsery/details/serialization_common.h"
 
 //
 
 namespace bitsery {
+template<>
+struct SelectSerializeFnc<afterhours::BaseComponent> : UseNonMemberFnc {};
+template<>
+struct SelectSerializeFnc<Transform> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasName> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanHoldItem> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<SimpleColoredBoxRenderer> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanBeHighlighted> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanHighlightOthers> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanHoldFurniture> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanBeGhostPlayer> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanPerformJob> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<ModelRenderer> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanBePushed> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CustomHeldItemPosition> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasWork> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasBaseSpeed> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsSolid> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanBeHeld> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasPatience> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasProgression> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsRotatable> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanGrabFromOtherFurniture> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<ConveysHeldItem> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasWaitingQueue> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanBeTakenFrom> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsItemContainer> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<UsesCharacterModel> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasDynamicModelName> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsTriggerArea> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasSpeechBubble> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<Indexer> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsSpawner> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasRopeToItem> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasSubtype> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsItem> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsDrink> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<AddsIngredient> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanOrderDrink> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsPnumaticPipe> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsProgressionManager> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsFloorMarker> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsBank> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsFreeInStore> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsToilet> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanPathfind> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsRoundSettingsManager> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<AIComponent> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasFishingGame> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsStoreSpawned> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<AICloseTab> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<AIPlayJukebox> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasLastInteractedCustomer> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanChangeSettingsInteractively> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsNuxManager> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsNux> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<AIWandering> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CollectsUserInput> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsSnappable> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasClientID> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<RespondsToUserInput> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CanHoldHandTruck> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<RespondsToDayNight> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<HasDayNightTimer> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<CollectsCustomerFeedback> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<IsSquirter> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<Type> : UseMemberFnc {};
+
+//
+
+template<>
+struct SelectSerializeFnc<AICleanVomit> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<AIUseBathroom> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<AIDrinking> : UseMemberFnc {};
+template<>
+struct SelectSerializeFnc<AIWaitInQueue> : UseMemberFnc {};
+//
+template<>
+struct SelectSerializeFnc<CanBeHeld_HT> : UseMemberFnc {};
 
 namespace ext {
+
 template<>
 struct PolymorphicBaseClass<BaseComponent>
     : PolymorphicDerivedClasses<
@@ -93,7 +241,7 @@ struct PolymorphicBaseClass<BaseComponent>
           CanChangeSettingsInteractively, IsNuxManager, IsNux, AIWandering,
           CollectsUserInput, IsSnappable, HasClientID, RespondsToUserInput,
           CanHoldHandTruck, RespondsToDayNight, HasDayNightTimer,
-          CollectsCustomerFeedback, IsSquirter
+          CollectsCustomerFeedback, IsSquirter, Type
           // END
           > {};
 // If you add anything here ^^ then you should add that component to

--- a/src/network/polymorphic_components.h
+++ b/src/network/polymorphic_components.h
@@ -77,6 +77,7 @@
 namespace bitsery {
 template<>
 struct SelectSerializeFnc<afterhours::BaseComponent> : UseNonMemberFnc {};
+
 template<>
 struct SelectSerializeFnc<Transform> : UseMemberFnc {};
 template<>
@@ -229,8 +230,8 @@ struct PolymorphicBaseClass<BaseComponent>
           Transform, HasName, CanHoldItem, SimpleColoredBoxRenderer,
           CanBeHighlighted, CanHighlightOthers, CanHoldFurniture,
           CanBeGhostPlayer, CanPerformJob, ModelRenderer, CanBePushed,
-          CustomHeldItemPosition, HasWork, HasBaseSpeed, IsSolid, CanBeHeld,
-          HasPatience, HasProgression, IsRotatable, CanGrabFromOtherFurniture,
+          CustomHeldItemPosition, HasWork, HasBaseSpeed, IsSolid, HasPatience,
+          HasProgression, IsRotatable, CanGrabFromOtherFurniture,
           ConveysHeldItem, HasWaitingQueue, CanBeTakenFrom, IsItemContainer,
           UsesCharacterModel, HasDynamicModelName, IsTriggerArea,
           HasSpeechBubble, Indexer, IsSpawner, HasRopeToItem, HasSubtype,
@@ -241,7 +242,9 @@ struct PolymorphicBaseClass<BaseComponent>
           CanChangeSettingsInteractively, IsNuxManager, IsNux, AIWandering,
           CollectsUserInput, IsSnappable, HasClientID, RespondsToUserInput,
           CanHoldHandTruck, RespondsToDayNight, HasDayNightTimer,
-          CollectsCustomerFeedback, IsSquirter, Type
+          CollectsCustomerFeedback, IsSquirter, Type,
+          //
+          CanBeHeld
           // END
           > {};
 // If you add anything here ^^ then you should add that component to
@@ -267,4 +270,5 @@ struct PolymorphicBaseClass<CanBeHeld> : PolymorphicDerivedClasses<
 }  // namespace bitsery
 
 using MyPolymorphicClasses =
-    bitsery::ext::PolymorphicClassesList<BaseComponent, AIComponent, Job>;
+    bitsery::ext::PolymorphicClassesList<afterhours::BaseComponent, AIComponent,
+                                         Job>;

--- a/src/system/input_process_manager.cpp
+++ b/src/system/input_process_manager.cpp
@@ -19,6 +19,8 @@
 #include "../components/is_snappable.h"
 #include "../components/responds_to_user_input.h"
 #include "../components/transform.h"
+#include "../engine/assert.h"
+#include "../engine/log.h"
 #include "../entity.h"
 #include "../entity_helper.h"
 #include "../network/server.h"
@@ -374,7 +376,7 @@ void drop_held_furniture(Entity& player) {
 }
 
 void handle_grab_or_drop(Entity& player) {
-    log_info("Handle grab or drop, player is {}", player.type);
+    log_info("Handle grab or drop, player is {}", player.get<Type>().type);
     const CanHighlightOthers& cho = player.get<CanHighlightOthers>();
     CanHoldFurniture& ourCHF = player.get<CanHoldFurniture>();
 

--- a/src/system/logging_system.h
+++ b/src/system/logging_system.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "../components/transform.h"
+#include "../components/type.h"
 #include "../engine/is_server.h"
 #include "../entity.h"
 
@@ -11,7 +12,7 @@ inline void announce(const Entity& entity, const std::string& text) {
     // TODO have some way of distinguishing between server logs and regular
     // client logs
     if (is_server()) {
-        log_trace("server: {}({})@{}: {}", entity.name(), entity.id,
+        log_trace("server: {}({})@{}: {}", entity.get<Type>().name(), entity.id,
                   entity.get<Transform>().pos(), text);
     } else {
         // log_info("client: {}: {}", this->id, text);

--- a/src/system/rendering_system.cpp
+++ b/src/system/rendering_system.cpp
@@ -1060,7 +1060,7 @@ void render_waiting_queue(const Entity& entity, float) {
 }
 
 void render_price(const Entity& entity, float) {
-    int price = get_price_for_entity_type(entity.type);
+    int price = get_price_for_entity_type(entity.get<Type>().type);
     if (price == -1) return;
 
     if (entity.is_missing<Transform>()) return;
@@ -1095,9 +1095,9 @@ void render_machine_name(const Entity& entity, int font_size = 200) {
     if (!someone_close) return;
 
     // TODO rotate the name with the camera?
-    raylib::DrawFloatingText(transform.raw() + vec3{0.3f, 0.2f, 0.5f},
-                             Preload::get().font,
-                             std::string(entity.name()).c_str(), font_size);
+    raylib::DrawFloatingText(
+        transform.raw() + vec3{0.3f, 0.2f, 0.5f}, Preload::get().font,
+        std::string(entity.get<Type>().name()).c_str(), font_size);
 }
 
 void render_debug_fruit_juice(const Entity& entity, float) {

--- a/src/system/system_manager.cpp
+++ b/src/system/system_manager.cpp
@@ -1701,7 +1701,8 @@ bool _create_nuxes(Entity&) {
                         .whereType(EntityType::Register)
                         .whereIsHoldingItemOfType(EntityType::Drink)
                         .whereHeldItemMatches([](const Entity& item) {
-                            if (item.type != EntityType::Drink) return false;
+                            if (item.get<Type>().type != EntityType::Drink)
+                                return false;
                             return item.get<IsDrink>().matches_drink(
                                 Drink::coke);
                         })
@@ -2409,8 +2410,8 @@ void cart_management(Entity& entity, float) {
         // it was already purchased or is otherwise just randomly in the store
         if (marked_entity->is_missing<IsStoreSpawned>()) continue;
 
-        amount_in_cart +=
-            std::max(0, get_price_for_entity_type(marked_entity->type));
+        amount_in_cart += std::max(
+            0, get_price_for_entity_type(marked_entity->get<Type>().type));
     }
 
     OptEntity sophie = EntityQuery().whereType(EntityType::Sophie).gen_first();
@@ -2588,8 +2589,8 @@ void move_purchased_furniture() {
 
         // Its not free!
         if (marked_entity->is_missing<IsFreeInStore>()) {
-            amount_in_cart +=
-                std::max(0, get_price_for_entity_type(marked_entity->type));
+            amount_in_cart += std::max(
+                0, get_price_for_entity_type(marked_entity->get<Type>().type));
         }
     }
 

--- a/src/system/system_manager.h
+++ b/src/system/system_manager.h
@@ -1,8 +1,11 @@
 
 #pragma once
 
+#include "../engine/keymap.h"
 #include "../engine/singleton.h"
 #include "../entity.h"
+
+using afterhours::Entities;
 
 namespace system_manager {
 namespace job_system {

--- a/src/system/ui_rendering_system.cpp
+++ b/src/system/ui_rendering_system.cpp
@@ -11,6 +11,8 @@
 #include "../components/has_waiting_queue.h"
 #include "../components/is_bank.h"
 #include "../components/model_renderer.h"
+#include "../engine/assert.h"
+#include "../engine/log.h"
 #include "../entity_helper.h"
 #include "../entity_query.h"
 #include "system_manager.h"
@@ -51,7 +53,7 @@ void render_current_register_queue(float dt) {
                 if (entity.is_missing<CanOrderDrink>()) {
                     log_warn(
                         "register {} has people who cant order in line: {}", i,
-                        entity.name());
+                        entity.get<Type>().name());
                     continue;
                 }
 
@@ -144,7 +146,7 @@ void render_networked_players(const Entities& entities, float dt) {
         if (entity.is_missing<ModelRenderer>()) {
             log_warn(
                 "render_little_model_guy, entity {} is missing model renderer",
-                entity.name());
+                entity.get<Type>().name());
             return;
         }
         auto model_name = entity.get<ModelRenderer>().name();

--- a/src/system/ui_rendering_system.h
+++ b/src/system/ui_rendering_system.h
@@ -5,6 +5,8 @@
 
 extern ui::UITheme UI_THEME;
 
+using afterhours::Entities;
+
 namespace system_manager {
 namespace ui {
 


### PR DESCRIPTION
## Problem
raylib 5.5 changed the rounded-rectangle-lines API:
- `DrawRectangleRoundedLines(rec, roundness, segments, color)` — **dropped** its `lineThick` parameter
- thickness now lives in `DrawRectangleRoundedLinesEx(rec, roundness, segments, lineThick, color)`

Both pharmasea call sites pass a `lineThick`, so they fail to compile against raylib 5.5:
- `src/layers/streamersafelayer.h:31`
- `src/engine/ui/ui_internal.h:112`

## Fix
Point both at `DrawRectangleRoundedLinesEx` — same 5 args, same behavior (thickness preserved).

## Verification
Compile-only (boulder has Santa Lockdown; can't run binaries). Confirmed `DrawRectangleRoundedLinesEx` resolves against the installed raylib 5.5, and **0 remaining `DrawRectangleRoundedLines` compile errors** in either header with pharmasea's exact Makefile flags (`-std=c++2a`, pkg-config raylib, `-DRAYMATH_DISABLE_CPP_OPERATORS`, `-Ivendor/`).

## Note
Branched off `afterhours` (the clean active branch) rather than `main` — `main` currently has an in-progress rebase locally. This fix is independent of that. This error was surfaced while verifying afterhours consumers against latest main; it's a raylib-version issue, **not** an afterhours API break (afterhours bump introduced zero regressions).